### PR TITLE
github actions ci/cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: GoReleaser build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.x'
+        id: go
+
+      - name: run GoReleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          version: latest
+          args: release --rm-dist -p 2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+project_name: smap
+builds:
+  - main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - mips
+    goarm:
+        - 7
+    ignore:
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: mips
+      - goos: windows
+        goarch: arm
+        goarm: 7
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: mips
+
+archives:
+    - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ .Arm }}"
+      format: tar.xz
+      format_overrides:
+        - goos: windows
+          format: zip
+      replacements:
+          darwin: macOS
+      wrap_in_directory: true
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}--sha256_checksums.txt"
+release:
+  draft: true
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
 project_name: smap
 builds:
   - main: .
+    binary: smap
+    dir: ./cmd/smap
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This PR allows GitHub Actions to use `goreleaser` to automatically build Release binaries for you.

Notes:

* This only occurs when a `tag` is created with a command set like: 

```shell
CURRENT=1.0.1
git tag -a "v${CURRENT}" -m "releasing version ${CURRENT}"
git push origin "v${CURRENT}"
```
* This also creates a `draft` release which allows you to review it before publishing to a full release.
