### PR TITLE
Renaming module will break the build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module smap
+module github.com/s0md3v/smap
 
 go 1.18
 


### PR DESCRIPTION
The module name change from github.com/s0md3v/smap will cause an error with the require statement:

``` 
go install -v github.com/s0md3v/smap/cmd/smap@latest
go.mod:
        module declares its path as: smap
                but was required as: github.com/s0md3v/smap
```

By the way I checked out your v.0.1.1 and there is still mismatched tag problem in ther XML output. The port tag is not closed if no service string is found. Can it be you build the releases with the wrong checkout? 

