### PR TITLE
add port format A-B

### DIFF
--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -60,6 +60,9 @@ func getPorts() []int {
 					for i := start; i < end; i++ {
 						thesePorts = append(thesePorts, i)
 					}
+				} else {
+					fmt.Fprint(os.Stderr, "' ' is not a valid port number.\nQUITTING!\n")
+					os.Exit(1)
 				}
 			} else if len(portList) == 1 {
 				intPort, err := strconv.Atoi(portList[0])

--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -48,9 +48,27 @@ func getPorts() []int {
 	thesePorts := []int{}
 	if value, ok := g.Args["p"]; ok {
 		for _, port := range strings.Split(value, ",") {
-			intPort, err := strconv.Atoi(port)
-			if err == nil && intPort >= 0 && intPort <= 65535 {
-				thesePorts = append(thesePorts, intPort)
+			portList := strings.Split(port, "-")
+			if len(portList) == 2 {
+				start, err := strconv.Atoi(portList[0])
+				if err != nil {
+					fmt.Fprint(os.Stderr, "' ' is not a valid port number.\nQUITTING!\n")
+					os.Exit(1)
+				}
+				end, err := strconv.Atoi(portList[1])
+				if err == nil && start >= 0 && start <= end && end <= 65535 {
+					for i := start; i < end; i++ {
+						thesePorts = append(thesePorts, i)
+					}
+				}
+			} else if len(portList) == 1 {
+				intPort, err := strconv.Atoi(portList[0])
+				if err == nil && intPort >= 0 && intPort <= 65535 {
+					thesePorts = append(thesePorts, intPort)
+				} else {
+					fmt.Fprint(os.Stderr, "' ' is not a valid port number.\nQUITTING!\n")
+					os.Exit(1)
+				}
 			} else {
 				fmt.Fprint(os.Stderr, "' ' is not a valid port number.\nQUITTING!\n")
 				os.Exit(1)
@@ -149,7 +167,7 @@ func handleOutput() {
 		continueOutput = []func(g.Output){o.ContinueSmap}
 		endOutput = []func(){o.EndSmap}
 		g.SmapFilename = value
-	}  else if value, ok := g.Args["oP"]; ok {
+	} else if value, ok := g.Args["oP"]; ok {
 		startOutput = []func(){o.StartPair}
 		continueOutput = []func(g.Output){o.ContinuePair}
 		endOutput = []func(){o.EndPair}


### PR DESCRIPTION
-p arg can accept A-B format port now
```
./smap 80,90,1-443 1.1.1.1
Starting Nmap 9.99 ( https://nmap.org ) at 2022-10-19 17:22 CST
Nmap scan report for one.one.one.one (1.1.1.1)
Host is up.

PORT    STATE SERVICE  VERSION
53/tcp  open  domain?  
80/tcp  open  http?    
443/tcp open  https?   

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 0.65 seconds
```