### PR TITLE
Snap created

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,0 +1,25 @@
+name: 🧪 Test snap can be built on x86_64
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'false'
+          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
+          # plugs: ./plug-declaration.json
+          # slots: ./slot-declaration.json

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: smap
+adopt-info: smap
+summary: Smap is a port scanner built with shodan.io's free API
+description: |
+  Smap is a port scanner built with shodan.io's free API. 
+  It takes same command line arguments as Nmap and produces the same output which 
+  makes it a drop-in replacament for Nmap.
+  
+base: core20
+grade: stable 
+confinement: strict
+compression: lzo
+license: AGPL-3.0
+
+apps:
+  smap:
+    command: bin/smap
+    plugs:
+      - home
+      - network
+      
+parts:
+  smap:
+    source: https://github.com/s0md3v/Smap
+    source-type: git
+    plugin: go
+    build-snaps:
+      - go
+      
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
+      
+    override-build: |
+      go install -v github.com/s0md3v/smap/cmd/smap@latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Smap is a port scanner built with shodan.io's free API
 description: |
   Smap is a port scanner built with shodan.io's free API. 
   It takes same command line arguments as Nmap and produces the same output which 
-  makes it a drop-in replacament for Nmap.
+  makes it a drop-in replacement for Nmap.
   
 base: core20
 grade: stable 
@@ -18,6 +18,7 @@ apps:
     plugs:
       - home
       - network
+      - network-bind
       
 parts:
   smap:


### PR DESCRIPTION
I created the snap to help with the distribution of `Smap`. If you'd like to publish it on https://snapcraft.io/, just follow these [directions](https://snapcraft.io/build). I've tested the snap locally, and it seems to be working, albeit slightly different results as compared to `nmap`. That said, I am not totally familiar with `Smap`, so there may be some differences in the commands being used. The readme didn't expressly state as much. 

In any case, I hope this helps your project along and improves distribution among the various Linux distros. 